### PR TITLE
Cxf 3.1.6 tt -  CVE backports

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/core/src/main/java/org/apache/cxf/attachment/AttachmentDeserializer.java
+++ b/core/src/main/java/org/apache/cxf/attachment/AttachmentDeserializer.java
@@ -29,17 +29,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.activation.DataSource;
 
+import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.HttpHeaderHelper;
 import org.apache.cxf.helpers.IOUtils;
 import org.apache.cxf.io.CachedOutputStream;
 import org.apache.cxf.message.Attachment;
 import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
 
 public class AttachmentDeserializer {
     public static final String ATTACHMENT_PART_HEADERS = AttachmentDeserializer.class.getName() + ".headers";
@@ -49,6 +52,12 @@ public class AttachmentDeserializer {
 
     public static final String ATTACHMENT_MAX_SIZE = "attachment-max-size";
 
+    /**
+     * The maximum MIME Header Length. The default is 300.
+     */
+    public static final String ATTACHMENT_MAX_HEADER_SIZE = "attachment-max-header-size";
+    public static final int DEFAULT_MAX_HEADER_SIZE = 300;
+
     public static final int THRESHOLD = 1024 * 100; //100K (byte unit)
 
     private static final Pattern CONTENT_TYPE_BOUNDARY_PATTERN = Pattern.compile("boundary=\"?([^\";]*)");
@@ -57,6 +66,8 @@ public class AttachmentDeserializer {
     // It seems constricting to assume the boundary will start with ----=_Part_
     private static final Pattern INPUT_STREAM_BOUNDARY_PATTERN =
             Pattern.compile("^--(\\S*)$", Pattern.MULTILINE);
+
+    private static final Logger LOG = LogUtils.getL7dLogger(AttachmentDeserializer.class);
 
     private boolean lazyLoading = true;
 
@@ -79,6 +90,8 @@ public class AttachmentDeserializer {
     private Set<DelegatingInputStream> loaded = new HashSet<DelegatingInputStream>();
     private List<String> supportedTypes;
 
+    private int maxHeaderLength = DEFAULT_MAX_HEADER_SIZE;
+
     public AttachmentDeserializer(Message message) {
         this(message, Collections.singletonList("multipart/related"));
     }
@@ -86,6 +99,10 @@ public class AttachmentDeserializer {
     public AttachmentDeserializer(Message message, List<String> supportedTypes) {
         this.message = message;
         this.supportedTypes = supportedTypes;
+
+        // Get the maximum Header length from configuration
+        maxHeaderLength = MessageUtils.getContextualInteger(message, ATTACHMENT_MAX_HEADER_SIZE,
+                                                            DEFAULT_MAX_HEADER_SIZE);
     }
     
     public void initializeAttachments() throws IOException {
@@ -267,6 +284,7 @@ public class AttachmentDeserializer {
             new DelegatingInputStream(new MimeBodyPartInputStream(stream, boundary, pbAmount),
                                       this);
         createCount++;
+
         return AttachmentUtil.createAttachment(partStream, headers);
     }
 
@@ -315,6 +333,7 @@ public class AttachmentDeserializer {
         StringBuilder buffer = new StringBuilder(128);
         StringBuilder b = new StringBuilder(128);
         Map<String, List<String>> heads = new TreeMap<String, List<String>>(String.CASE_INSENSITIVE_ORDER);
+
         // loop until we hit the end or a null line
         while (readLine(in, b)) {
             // lines beginning with white space get special handling
@@ -360,6 +379,11 @@ public class AttachmentDeserializer {
             } else {
                 // just add to the buffer
                 buffer.append((char)c);
+            }
+
+            if (buffer.length() > maxHeaderLength) {
+                LOG.fine("The attachment header size has exceeded the configured parameter: " + maxHeaderLength);
+                throw new HeaderSizeExceededException();
             }
         }
 

--- a/core/src/main/java/org/apache/cxf/attachment/ContentDisposition.java
+++ b/core/src/main/java/org/apache/cxf/attachment/ContentDisposition.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 public class ContentDisposition {
     private static final String CD_HEADER_PARAMS_EXPRESSION =
-        "(([\\w-]+( )?\\*?=( )?\"[^\"]+\")|([\\w-]+( )?\\*?=( )?[^;]+))";
+       "[\\w-]++( )?\\*?=( )?((\"[^\"]++\")|([^;]+))";
     private static final Pattern CD_HEADER_PARAMS_PATTERN =
             Pattern.compile(CD_HEADER_PARAMS_EXPRESSION);
 

--- a/core/src/main/java/org/apache/cxf/attachment/HeaderSizeExceededException.java
+++ b/core/src/main/java/org/apache/cxf/attachment/HeaderSizeExceededException.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.attachment;
+
+public class HeaderSizeExceededException extends RuntimeException {
+    private static final long serialVersionUID = -8976580055837650080L;
+
+    public HeaderSizeExceededException() {
+        super();
+    }
+
+    public HeaderSizeExceededException(String message) {
+        super(message);
+    }
+
+    public HeaderSizeExceededException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public HeaderSizeExceededException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/core/src/main/java/org/apache/cxf/message/MessageUtils.java
+++ b/core/src/main/java/org/apache/cxf/message/MessageUtils.java
@@ -19,8 +19,11 @@
 
 package org.apache.cxf.message;
 
+import java.util.logging.Logger;
+
 import org.w3c.dom.Node;
 
+import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.PropertyUtils;
 
 
@@ -28,6 +31,8 @@ import org.apache.cxf.common.util.PropertyUtils;
  * Holder for utility methods relating to messages.
  */
 public final class MessageUtils {
+
+    private static final Logger LOG = LogUtils.getL7dLogger(MessageUtils.class);
 
     /**
      * Prevents instantiation.
@@ -37,7 +42,7 @@ public final class MessageUtils {
 
     /**
      * Determine if message is outbound.
-     * 
+     *
      * @param message the current Message
      * @return true if the message direction is outbound
      */
@@ -49,7 +54,7 @@ public final class MessageUtils {
 
     /**
      * Determine if message is fault.
-     * 
+     *
      * @param message the current Message
      * @return true if the message is a fault
      */
@@ -59,11 +64,11 @@ public final class MessageUtils {
                && (message == message.getExchange().getInFaultMessage() || message == message.getExchange()
                    .getOutFaultMessage());
     }
-    
+
     /**
-     * Determine the fault mode for the underlying (fault) message 
+     * Determine the fault mode for the underlying (fault) message
      * (for use on server side only).
-     * 
+     *
      * @param message the fault message
      * @return the FaultMode
      */
@@ -78,12 +83,12 @@ public final class MessageUtils {
                 return FaultMode.RUNTIME_FAULT;
             }
         }
-        return null;    
+        return null;
     }
 
     /**
      * Determine if current messaging role is that of requestor.
-     * 
+     *
      * @param message the current Message
      * @return true if the current messaging role is that of requestor
      */
@@ -91,21 +96,21 @@ public final class MessageUtils {
         Boolean requestor = (Boolean)message.get(Message.REQUESTOR_ROLE);
         return requestor != null && requestor.booleanValue();
     }
-    
+
     /**
      * Determine if the current message is a partial response.
-     * 
+     *
      * @param message the current message
      * @return true if the current messags is a partial response
      */
     public static boolean isPartialResponse(Message message) {
         return Boolean.TRUE.equals(message.get(Message.PARTIAL_RESPONSE_MESSAGE));
     }
-    
+
     /**
      * Determines if the current message is an empty partial response, which
      * is a partial response with an empty content.
-     * 
+     *
      * @param message the current message
      * @return true if the current messags is a partial empty response
      */
@@ -122,7 +127,7 @@ public final class MessageUtils {
         // TODO - consider deprecation as this really belongs in PropertyUtils
         return PropertyUtils.isTrue(value);
     }
-    
+
     public static boolean getContextualBoolean(Message m, String key, boolean defaultValue) {
         if (m != null) {
             Object o = m.getContextualProperty(key);
@@ -132,7 +137,24 @@ public final class MessageUtils {
         }
         return defaultValue;
     }
-    
+
+    public static int getContextualInteger(Message m, String key, int defaultValue) {
+        if (m != null) {
+            Object o = m.getContextualProperty(key);
+            if (o instanceof String) {
+                try {
+                    int i = Integer.parseInt((String)o);
+                    if (i > 0) {
+                        return i;
+                    }
+                } catch (NumberFormatException ex) {
+                    LOG.warning("Incorrect integer value of " + o + " specified for: " + key);
+                }
+            }
+        }
+        return defaultValue;
+    }
+
     public static Object getContextualProperty(Message m, String propPreferred, String propDefault) {
         Object prop = m.getContextualProperty(propPreferred);
         if (prop == null && propDefault != null) {
@@ -140,7 +162,7 @@ public final class MessageUtils {
         }
         return prop;
     }
-    
+
     /**
      * Returns true if the underlying content format is a W3C DOM or a SAAJ message.
      */
@@ -150,7 +172,7 @@ public final class MessageUtils {
         for (Class c : m.getContentFormats()) {
             if (c.equals(Node.class) || c.getName().equals("javax.xml.soap.SOAPMessage")) {
                 return true;
-            }   
+            }
         }
         return false;
         */

--- a/distribution/javadoc/pom.xml
+++ b/distribution/javadoc/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent</relativePath>
     </parent>
     <dependencies>

--- a/distribution/manifest/pom.xml
+++ b/distribution/manifest/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent</relativePath>
     </parent>
     <properties>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
     <properties>

--- a/distribution/src/main/release/samples/aegis/pom.xml
+++ b/distribution/src/main/release/samples/aegis/pom.xml
@@ -99,24 +99,24 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-databinding-aegis</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- The server example in here launches the embedded jetty. Not needed
              if you deploy a WAR. -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/distribution/src/main/release/samples/aegis_standalone/pom.xml
+++ b/distribution/src/main/release/samples/aegis_standalone/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-databinding-aegis</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.stax-utils</groupId>

--- a/distribution/src/main/release/samples/callback/pom.xml
+++ b/distribution/src/main/release/samples/callback/pom.xml
@@ -117,17 +117,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/configuration_interceptor/pom.xml
+++ b/distribution/src/main/release/samples/configuration_interceptor/pom.xml
@@ -120,22 +120,22 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-management</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/corba/bank/pom.xml
+++ b/distribution/src/main/release/samples/corba/bank/pom.xml
@@ -117,17 +117,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-bindings-corba</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-tools-common</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/corba/bank_ws_addressing/pom.xml
+++ b/distribution/src/main/release/samples/corba/bank_ws_addressing/pom.xml
@@ -224,17 +224,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-bindings-corba</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-tools-common</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/corba/hello_world/pom.xml
+++ b/distribution/src/main/release/samples/corba/hello_world/pom.xml
@@ -269,17 +269,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-bindings-corba</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-tools-common</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/groovy_spring_support/pom.xml
+++ b/distribution/src/main/release/samples/groovy_spring_support/pom.xml
@@ -99,18 +99,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/distribution/src/main/release/samples/in_jvm_transport/pom.xml
+++ b/distribution/src/main/release/samples/in_jvm_transport/pom.xml
@@ -87,23 +87,23 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-bindings-coloc</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/java_first_jaxws/pom.xml
+++ b/distribution/src/main/release/samples/java_first_jaxws/pom.xml
@@ -113,12 +113,12 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/java_first_jaxws_factory_bean/pom.xml
+++ b/distribution/src/main/release/samples/java_first_jaxws_factory_bean/pom.xml
@@ -82,18 +82,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/java_first_jms/pom.xml
+++ b/distribution/src/main/release/samples/java_first_jms/pom.xml
@@ -101,12 +101,12 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-jms</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/java_first_pojo/pom.xml
+++ b/distribution/src/main/release/samples/java_first_pojo/pom.xml
@@ -82,18 +82,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/java_first_spring_support/pom.xml
+++ b/distribution/src/main/release/samples/java_first_spring_support/pom.xml
@@ -96,17 +96,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/jax_rs/basic/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/basic/pom.xml
@@ -84,18 +84,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- This dependency is needed if you're using the Jetty container -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>

--- a/distribution/src/main/release/samples/jax_rs/basic_oidc/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/basic_oidc/pom.xml
@@ -35,22 +35,22 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-security-jose-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-security-sso-oidc</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency> 
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/distribution/src/main/release/samples/jax_rs/big_query/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/big_query/pom.xml
@@ -35,27 +35,27 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-security-jose-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-extension-providers</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-security-sso-oidc</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency> 
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/distribution/src/main/release/samples/jax_rs/content_negotiation/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/content_negotiation/pom.xml
@@ -84,23 +84,23 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- This dependency is needed if you're using the Jetty container -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-extension-providers</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jettison</groupId>

--- a/distribution/src/main/release/samples/jax_rs/description_swagger/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/description_swagger/pom.xml
@@ -125,23 +125,23 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- This dependency is needed if you're using the Jetty container -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-service-description</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/distribution/src/main/release/samples/jax_rs/description_swagger2/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/description_swagger2/pom.xml
@@ -119,23 +119,23 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- This dependency is needed if you're using the Jetty container -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-service-description</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>

--- a/distribution/src/main/release/samples/jax_rs/description_swagger2_osgi/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/description_swagger2_osgi/pom.xml
@@ -87,17 +87,17 @@ under the License.
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-service-description</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/distribution/src/main/release/samples/jax_rs/description_swagger2_web/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/description_swagger2_web/pom.xml
@@ -137,17 +137,17 @@ under the License.
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-service-description</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/distribution/src/main/release/samples/jax_rs/jaxrs_spring_boot/src/main/java/sample/rs/service/SampleRestApplication.java
+++ b/distribution/src/main/release/samples/jax_rs/jaxrs_spring_boot/src/main/java/sample/rs/service/SampleRestApplication.java
@@ -51,7 +51,7 @@ public class SampleRestApplication {
         JAXRSServerFactoryBean endpoint = new JAXRSServerFactoryBean();
         endpoint.setBus(bus);
         endpoint.setServiceBeans(Arrays.<Object>asList(new HelloServiceImpl1(), new HelloServiceImpl2()));
-        endpoint.setAddress("/a");
+        endpoint.setAddress("/");
         endpoint.setFeatures(Arrays.asList(new Swagger2Feature()));
         return endpoint.create();
     }

--- a/distribution/src/main/release/samples/jax_rs/jaxrs_spring_boot/src/main/java/sample/rs/service/SampleRestApplication.java
+++ b/distribution/src/main/release/samples/jax_rs/jaxrs_spring_boot/src/main/java/sample/rs/service/SampleRestApplication.java
@@ -44,14 +44,16 @@ public class SampleRestApplication {
     public ServletRegistrationBean servletRegistrationBean(ApplicationContext context) {
         return new ServletRegistrationBean(new CXFServlet(), "/services/*");
     }
- 
-    
+
+
     @Bean
     public Server rsServer() {
         JAXRSServerFactoryBean endpoint = new JAXRSServerFactoryBean();
-        endpoint.setServiceBeans(Arrays.asList(new HelloService(), new HelloService2()));
-        endpoint.setAddress("/helloservice");
+        endpoint.setBus(bus);
+        endpoint.setServiceBeans(Arrays.<Object>asList(new HelloServiceImpl1(), new HelloServiceImpl2()));
+        endpoint.setAddress("/a");
+        endpoint.setFeatures(Arrays.asList(new Swagger2Feature()));
         return endpoint.create();
     }
- 
+
 }

--- a/distribution/src/main/release/samples/jax_rs/search/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/search/pom.xml
@@ -85,33 +85,33 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- This dependency is needed if you're using the Jetty container -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-extension-search</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-extension-providers</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>                 
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-security-cors</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency> 
         <dependency>
             <groupId>org.apache.lucene</groupId>

--- a/distribution/src/main/release/samples/jax_rs/spring_security/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/spring_security/pom.xml
@@ -89,18 +89,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- This dependency is needed if you're using the Jetty container -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>

--- a/distribution/src/main/release/samples/jax_rs/tracing_htrace/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/tracing_htrace/pom.xml
@@ -84,33 +84,33 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- This dependency is needed if you're using the Jetty container -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-client</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>    
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-integration-tracing-htrace</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-extension-providers</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.json</groupId>

--- a/distribution/src/main/release/samples/jax_rs/websocket/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/websocket/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- This dependency is needed if you're using the Jetty container -->
         <dependency>
@@ -170,17 +170,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-websocket</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/distribution/src/main/release/samples/jax_server_aegis_client/pom.xml
+++ b/distribution/src/main/release/samples/jax_server_aegis_client/pom.xml
@@ -82,23 +82,23 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-databinding-aegis</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/jaxws_async/pom.xml
+++ b/distribution/src/main/release/samples/jaxws_async/pom.xml
@@ -127,17 +127,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-hc</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -149,7 +149,7 @@
             <!-- Not needed if deploying to a Servlet 3 based container or non-jetty container -->
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>

--- a/distribution/src/main/release/samples/jaxws_dispatch_provider/pom.xml
+++ b/distribution/src/main/release/samples/jaxws_dispatch_provider/pom.xml
@@ -114,18 +114,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/jaxws_handlers/pom.xml
+++ b/distribution/src/main/release/samples/jaxws_handlers/pom.xml
@@ -114,18 +114,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/jms_pubsub/pom.xml
+++ b/distribution/src/main/release/samples/jms_pubsub/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-codegen-plugin</artifactId>
-                <version>3.1.6</version>
+                <version>3.1.6-TT-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-sources</id>
@@ -137,12 +137,12 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-jms</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/distribution/src/main/release/samples/jms_queue/pom.xml
+++ b/distribution/src/main/release/samples/jms_queue/pom.xml
@@ -137,12 +137,12 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-jms</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/distribution/src/main/release/samples/jms_spec_demo/pom.xml
+++ b/distribution/src/main/release/samples/jms_spec_demo/pom.xml
@@ -137,12 +137,12 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-jms</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/distribution/src/main/release/samples/jms_spring_config/pom.xml
+++ b/distribution/src/main/release/samples/jms_spring_config/pom.xml
@@ -146,12 +146,12 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-jms</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf.xjc-utils</groupId>

--- a/distribution/src/main/release/samples/js_browser_client_java_first/pom.xml
+++ b/distribution/src/main/release/samples/js_browser_client_java_first/pom.xml
@@ -59,22 +59,22 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-javascript</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/js_browser_client_simple/pom.xml
+++ b/distribution/src/main/release/samples/js_browser_client_simple/pom.xml
@@ -111,22 +111,22 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-javascript</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/js_client/pom.xml
+++ b/distribution/src/main/release/samples/js_client/pom.xml
@@ -113,22 +113,22 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-javascript</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>rhino</groupId>

--- a/distribution/src/main/release/samples/js_provider/pom.xml
+++ b/distribution/src/main/release/samples/js_provider/pom.xml
@@ -128,18 +128,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-js</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/mtom/pom.xml
+++ b/distribution/src/main/release/samples/mtom/pom.xml
@@ -115,18 +115,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>

--- a/distribution/src/main/release/samples/restful_dispatch/pom.xml
+++ b/distribution/src/main/release/samples/restful_dispatch/pom.xml
@@ -83,23 +83,23 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>

--- a/distribution/src/main/release/samples/ruby_spring_support/pom.xml
+++ b/distribution/src/main/release/samples/ruby_spring_support/pom.xml
@@ -99,18 +99,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jruby</groupId>

--- a/distribution/src/main/release/samples/soap_header/pom.xml
+++ b/distribution/src/main/release/samples/soap_header/pom.xml
@@ -114,18 +114,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/ws_addressing/pom.xml
+++ b/distribution/src/main/release/samples/ws_addressing/pom.xml
@@ -118,17 +118,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/ws_discovery/pom.xml
+++ b/distribution/src/main/release/samples/ws_discovery/pom.xml
@@ -37,22 +37,22 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf.services.ws-discovery</groupId>
             <artifactId>cxf-services-ws-discovery-api</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf.services.ws-discovery</groupId>
             <artifactId>cxf-services-ws-discovery-service</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/distribution/src/main/release/samples/ws_notification/pom.xml
+++ b/distribution/src/main/release/samples/ws_notification/pom.xml
@@ -82,32 +82,32 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-addr</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-policy</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf.services.wsn</groupId>
             <artifactId>cxf-services-wsn-core</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/ws_policy/pom.xml
+++ b/distribution/src/main/release/samples/ws_policy/pom.xml
@@ -113,17 +113,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/ws_rm/pom.xml
+++ b/distribution/src/main/release/samples/ws_rm/pom.xml
@@ -108,23 +108,23 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-rm</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/ws_security/sign_enc/pom.xml
+++ b/distribution/src/main/release/samples/ws_security/sign_enc/pom.xml
@@ -165,38 +165,38 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-rm</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-security</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-addr</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-policy</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/ws_security/ut/pom.xml
+++ b/distribution/src/main/release/samples/ws_security/ut/pom.xml
@@ -154,23 +154,23 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-security</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/distribution/src/main/release/samples/wsdl_first/pom.xml
+++ b/distribution/src/main/release/samples/wsdl_first/pom.xml
@@ -249,22 +249,22 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-management</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-features-metrics</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf.xjc-utils</groupId>

--- a/distribution/src/main/release/samples/wsdl_first_dynamic_client/pom.xml
+++ b/distribution/src/main/release/samples/wsdl_first_dynamic_client/pom.xml
@@ -112,18 +112,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/distribution/src/main/release/samples/wsdl_first_pure_xml/pom.xml
+++ b/distribution/src/main/release/samples/wsdl_first_pure_xml/pom.xml
@@ -114,18 +114,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/wsdl_first_rpclit/pom.xml
+++ b/distribution/src/main/release/samples/wsdl_first_rpclit/pom.xml
@@ -114,18 +114,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/wsdl_first_soap12/pom.xml
+++ b/distribution/src/main/release/samples/wsdl_first_soap12/pom.xml
@@ -114,18 +114,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/wsdl_first_xml_wrapped/pom.xml
+++ b/distribution/src/main/release/samples/wsdl_first_xml_wrapped/pom.xml
@@ -114,18 +114,18 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/distribution/src/main/release/samples/wsdl_first_xmlbeans/pom.xml
+++ b/distribution/src/main/release/samples/wsdl_first_xmlbeans/pom.xml
@@ -129,23 +129,23 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-databinding-xmlbeans</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <!-- Jetty is needed if you're using the CXFServlet -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>3.1.6</version>
+            <version>3.1.6-TT-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/integration/cdi/pom.xml
+++ b/integration/cdi/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     

--- a/integration/jca/pom.xml
+++ b/integration/jca/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>jca</module>

--- a/integration/tracing/tracing-htrace/pom.xml
+++ b/integration/tracing/tracing-htrace/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     

--- a/maven-plugins/archetypes/cxf-jaxrs-service/pom.xml
+++ b/maven-plugins/archetypes/cxf-jaxrs-service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <groupId>org.apache.cxf.archetype</groupId>

--- a/maven-plugins/archetypes/cxf-jaxws-javafirst/pom.xml
+++ b/maven-plugins/archetypes/cxf-jaxws-javafirst/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <groupId>org.apache.cxf.archetype</groupId>
     <artifactId>cxf-jaxws-javafirst</artifactId>
-    <version>3.1.6</version>
+    <version>3.1.6-TT-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>Apache CXF Archetype - Simple JAX-WS Java First</name>
     <description>Creates a project for developing a Web service starting from Java code</description>

--- a/maven-plugins/archetypes/pom.xml
+++ b/maven-plugins/archetypes/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-maven-plugins</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>cxf-jaxws-javafirst</module>

--- a/maven-plugins/codegen-plugin/pom.xml
+++ b/maven-plugins/codegen-plugin/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-maven-plugins</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/maven-plugins/corba/pom.xml
+++ b/maven-plugins/corba/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-maven-plugins</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/maven-plugins/java2wadl-plugin/pom.xml
+++ b/maven-plugins/java2wadl-plugin/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.cxf</groupId>
     <artifactId>cxf-java2wadl-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>3.1.6</version>
+    <version>3.1.6-TT-SNAPSHOT</version>
     <name>Apache CXF Java2WADL Maven2 Plugin</name>
     <description>Apache CXF Java2WADL Maven2 Plugin</description>
     <url>http://cxf.apache.org</url>
@@ -31,7 +31,7 @@
     <parent>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-maven-plugins</artifactId>
-      <version>3.1.6</version>
+      <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <properties>
         <cxf.manifest.location />

--- a/maven-plugins/java2ws-plugin/pom.xml
+++ b/maven-plugins/java2ws-plugin/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-maven-plugins</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
     <modules>

--- a/maven-plugins/wadl2java-plugin/pom.xml
+++ b/maven-plugins/wadl2java-plugin/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-maven-plugins</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/maven-plugins/wsdl-validator-plugin/pom.xml
+++ b/maven-plugins/wsdl-validator-plugin/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-maven-plugins</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/osgi/bundle/compatible/pom.xml
+++ b/osgi/bundle/compatible/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-bundle-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <properties>
         <cxf.osgi.symbolic.name>${project.groupId}.bundle</cxf.osgi.symbolic.name>

--- a/osgi/bundle/pom.xml
+++ b/osgi/bundle/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent</relativePath>
     </parent>
     <properties>

--- a/osgi/itests-felix/pom.xml
+++ b/osgi/itests-felix/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <groupId>org.apache.cxf.osgi.itests</groupId>

--- a/osgi/itests/pom.xml
+++ b/osgi/itests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <groupId>org.apache.cxf.osgi.itests</groupId>

--- a/osgi/karaf/commands/pom.xml
+++ b/osgi/karaf/commands/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.cxf.karaf</groupId>
         <artifactId>karaf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <artifactId>cxf-karaf-commands</artifactId>
     <packaging>bundle</packaging>

--- a/osgi/karaf/features/pom.xml
+++ b/osgi/karaf/features/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.cxf.karaf</groupId>
         <artifactId>karaf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <artifactId>apache-cxf</artifactId>
     <packaging>pom</packaging>

--- a/osgi/karaf/pom.xml
+++ b/osgi/karaf/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent</relativePath>
     </parent>
     <groupId>org.apache.cxf.karaf</groupId>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>bundle</module>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cxf-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.cxf</groupId>
     <artifactId>cxf</artifactId>
-    <version>3.1.6</version>
+    <version>3.1.6-TT-SNAPSHOT</version>
     <name>Apache CXF</name>
     <description>Apache CXF is an open-source services framework that aids in 
     the development of services using front-end programming APIs, like JAX-WS 

--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,10 @@
     <url>http://cxf.apache.org</url>
     <packaging>pom</packaging>
     <scm>
-        <connection>scm:git:http://git-wip-us.apache.org/repos/asf/cxf.git</connection>
-        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/cxf.git</developerConnection>
-        <url>https://git-wip-us.apache.org/repos/asf?p=cxf.git;a=summary</url>
-        <tag>cxf-3.1.6</tag>
+        <connection>scm:git:https://github.com/tomitribe/cxf.git</connection>
+        <developerConnection>scm:git:https://github.com/tomitribe/cxf.git</developerConnection>
+        <url>scm:git:https://github.com/tomitribe/cxf.git</url>
+        <tag>HEAD</tag>
     </scm>
     <issueManagement>
         <system>jira</system>
@@ -51,15 +51,15 @@
     </properties>
     <distributionManagement>
         <repository>
-            <id>apache.releases.https</id>
-            <name>Apache Release Distribution Repository</name>
-            <url>https://repository.apache.org/service/local/staging/deploy/maven2</url>
+            <id>tomitribe.releases.https</id>
+            <name>Tomitribe Release Distribution Repository</name>
+            <url>https://repository.tomitribe.com/service/local/staging/deploy/maven2</url>
         </repository>
+
         <snapshotRepository>
-            <id>apache.snapshots.https</id>
-            <name>Apache Development Snapshot Repository</name>
-            <url>https://repository.apache.org/content/repositories/snapshots</url>
-            <!--uniqueVersion>false</uniqueVersion-->
+            <id>tomitribe.snapshots.https</id>
+            <name>Tomitribe Development Snapshot Repository</name>
+            <url>https://repository.tomitribe.com/content/repositories/snapshots-tomitribe</url>
         </snapshotRepository>
         <site>
             <id>apache.cxf.site</id>

--- a/rt/bindings/coloc/pom.xml
+++ b/rt/bindings/coloc/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/bindings/corba/pom.xml
+++ b/rt/bindings/corba/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/bindings/object/pom.xml
+++ b/rt/bindings/object/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/bindings/pom.xml
+++ b/rt/bindings/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>soap</module>

--- a/rt/bindings/soap/pom.xml
+++ b/rt/bindings/soap/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/bindings/xml/pom.xml
+++ b/rt/bindings/xml/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/databinding/aegis/pom.xml
+++ b/rt/databinding/aegis/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     

--- a/rt/databinding/jaxb/pom.xml
+++ b/rt/databinding/jaxb/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/databinding/jibx/pom.xml
+++ b/rt/databinding/jibx/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/databinding/pom.xml
+++ b/rt/databinding/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>jaxb</module>

--- a/rt/databinding/sdo/pom.xml
+++ b/rt/databinding/sdo/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/databinding/xmlbeans/pom.xml
+++ b/rt/databinding/xmlbeans/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/features/clustering/pom.xml
+++ b/rt/features/clustering/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/features/logging/pom.xml
+++ b/rt/features/logging/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <artifactId>cxf-rt-features-logging</artifactId>

--- a/rt/features/metrics/pom.xml
+++ b/rt/features/metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <artifactId>cxf-rt-features-metrics</artifactId>

--- a/rt/features/pom.xml
+++ b/rt/features/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>clustering</module>

--- a/rt/features/throttling/pom.xml
+++ b/rt/features/throttling/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <artifactId>cxf-rt-features-throttling</artifactId>

--- a/rt/frontend/jaxrs/pom.xml
+++ b/rt/frontend/jaxrs/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/ext/MessageContextImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/ext/MessageContextImpl.java
@@ -45,6 +45,7 @@ import javax.ws.rs.ext.Providers;
 import org.apache.cxf.attachment.AttachmentDeserializer;
 import org.apache.cxf.attachment.AttachmentImpl;
 import org.apache.cxf.attachment.AttachmentUtil;
+import org.apache.cxf.attachment.HeaderSizeExceededException;
 import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.interceptor.AttachmentOutInterceptor;
@@ -68,7 +69,7 @@ public class MessageContextImpl implements MessageContext {
     public MessageContextImpl(Message m) {
         this.m = m;
     }
-    
+
     public Object get(Object key) {
         String keyValue = key.toString();
         if (MultipartBody.INBOUND_MESSAGE_ATTACHMENTS.equals(keyValue)
@@ -78,12 +79,14 @@ public class MessageContextImpl implements MessageContext {
             } catch (CacheSizeExceededException e) {
                 m.getExchange().put("cxf.io.cacheinput", Boolean.FALSE);
                 throw new WebApplicationException(e, 413);
+            } catch (HeaderSizeExceededException e) {
+                throw new WebApplicationException(e, 413);
             }
         }
         if (keyValue.equals("WRITE-" + Message.ATTACHMENTS)) {
             return m.getExchange().getOutMessage().get(Message.ATTACHMENTS);
         }
-        
+
         Message currentMessage = getCurrentMessage();
         Object value = currentMessage.get(key);
         if (value == null) {
@@ -92,7 +95,7 @@ public class MessageContextImpl implements MessageContext {
             }
             Exchange exchange = currentMessage.getExchange();
             if (exchange != null) {
-                Message otherMessage = exchange.getInMessage() == currentMessage 
+                Message otherMessage = exchange.getInMessage() == currentMessage
                     ? exchange.getOutMessage() : exchange.getInMessage();
                 if (otherMessage != null) {
                     value = otherMessage.get(key);
@@ -101,10 +104,10 @@ public class MessageContextImpl implements MessageContext {
                     value = m.getExchange().get(key);
                 }
             }
-        } 
+        }
         return value;
     }
-    
+
     private Message getCurrentMessage() {
         Message currentMessage = JAXRSUtils.getCurrentMessage();
         if (currentMessage == null) {
@@ -117,10 +120,10 @@ public class MessageContextImpl implements MessageContext {
         if (MessageUtils.isRequestor(m) && m.getExchange().getInMessage() != null) {
             Message inMessage = m.getExchange().getInMessage();
             return inMessage.getContent(format);
-        } 
+        }
         return m.getContent(format);
     }
-    
+
     public Object getContextualProperty(Object key) {
         Object value = m.getContextualProperty(key.toString());
         if (value == null && key.getClass() == Class.class) {
@@ -133,22 +136,22 @@ public class MessageContextImpl implements MessageContext {
     public <T> T getContext(Class<T> contextClass) {
         return getContext(contextClass, contextClass);
     }
-    
+
     protected <T> T getContext(Type genericType, Class<T> clazz) {
         return JAXRSUtils.createContextValue(m, genericType, clazz);
     }
-    
+
     public <T, E> T getResolver(Class<T> resolverClazz, Class<E> resolveClazz) {
         if (ContextResolver.class == resolverClazz) {
             return resolverClazz.cast(getContext(resolveClazz, ContextResolver.class));
         }
         return null;
     }
-    
+
     public Request getRequest() {
         return getContext(Request.class);
     }
-    
+
     public HttpHeaders getHttpHeaders() {
         return getContext(HttpHeaders.class);
     }
@@ -164,7 +167,7 @@ public class MessageContextImpl implements MessageContext {
     public UriInfo getUriInfo() {
         return getContext(UriInfo.class);
     }
-    
+
     public HttpServletRequest getHttpServletRequest() {
         try {
             return getContext(HttpServletRequest.class);
@@ -176,7 +179,7 @@ public class MessageContextImpl implements MessageContext {
     public HttpServletResponse getHttpServletResponse() {
         return getContext(HttpServletResponse.class);
     }
-    
+
     public ServletConfig getServletConfig() {
         return getContext(ServletConfig.class);
     }
@@ -192,14 +195,14 @@ public class MessageContextImpl implements MessageContext {
         Message currentMessage = getCurrentMessage();
         currentMessage.put(key.toString(), value);
         currentMessage.getExchange().put(key.toString(), value);
-            
+
     }
 
     private void convertToAttachments(Object value) {
         List<?> handlers = (List<?>)value;
-        List<org.apache.cxf.message.Attachment> atts = 
+        List<org.apache.cxf.message.Attachment> atts =
             new ArrayList<org.apache.cxf.message.Attachment>();
-        
+
         for (int i = 1; i < handlers.size(); i++) {
             Attachment handler = (Attachment)handlers.get(i);
             AttachmentImpl att = new AttachmentImpl(handler.getContentId(), handler.getDataHandler());
@@ -213,32 +216,32 @@ public class MessageContextImpl implements MessageContext {
         outMessage.setAttachments(atts);
         outMessage.put(AttachmentOutInterceptor.WRITE_ATTACHMENTS, "true");
         Attachment root = (Attachment)handlers.get(0);
-        
+
         String rootContentType = root.getContentType().toString();
         MultivaluedMap<String, String> rootHeaders = new MetadataMap<String, String>(root.getHeaders());
         if (!AttachmentUtil.isMtomEnabled(outMessage)) {
             rootHeaders.putSingle(Message.CONTENT_TYPE, rootContentType);
         }
-        
+
         String messageContentType = outMessage.get(Message.CONTENT_TYPE).toString();
         int index = messageContentType.indexOf(";type");
         if (index > 0) {
             messageContentType = messageContentType.substring(0, index).trim();
         }
-        AttachmentOutputInterceptor attInterceptor =          
+        AttachmentOutputInterceptor attInterceptor =
             new AttachmentOutputInterceptor(messageContentType, rootHeaders);
-        
+
         outMessage.put(Message.CONTENT_TYPE, rootContentType);
-        Map<String, List<String>> allHeaders = 
+        Map<String, List<String>> allHeaders =
             CastUtils.cast((Map<?, ?>)outMessage.get(Message.PROTOCOL_HEADERS));
         if (allHeaders != null) {
             allHeaders.remove(Message.CONTENT_TYPE);
         }
         attInterceptor.handleMessage(outMessage);
     }
-    
+
     private Message getOutMessage() {
-        
+
         Message message = m.getExchange().getOutMessage();
         if (message == null) {
             Endpoint ep = m.getExchange().getEndpoint();
@@ -247,51 +250,54 @@ public class MessageContextImpl implements MessageContext {
             message = ep.getBinding().createMessage(message);
             m.getExchange().setOutMessage(message);
         }
-        
+
         return message;
     }
-    
+
     private MultipartBody createAttachments(String propertyName) {
         Message inMessage = m.getExchange().getInMessage();
         boolean embeddedAttachment = inMessage.get("org.apache.cxf.multipart.embedded") != null;
-        
+
         Object o = inMessage.get(propertyName);
         if (o != null) {
             return (MultipartBody)o;
         }
-        
+
         if (embeddedAttachment) {
             inMessage = new MessageImpl();
             inMessage.setExchange(new ExchangeImpl());
-            inMessage.put(AttachmentDeserializer.ATTACHMENT_DIRECTORY, 
+            inMessage.put(AttachmentDeserializer.ATTACHMENT_DIRECTORY,
                 m.getExchange().getInMessage().get(AttachmentDeserializer.ATTACHMENT_DIRECTORY));
-            inMessage.put(AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, 
+            inMessage.put(AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD,
                 m.getExchange().getInMessage().get(AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD));
             inMessage.put(AttachmentDeserializer.ATTACHMENT_MAX_SIZE,
                 m.getExchange().getInMessage().get(AttachmentDeserializer.ATTACHMENT_MAX_SIZE));
-            inMessage.setContent(InputStream.class, 
+            inMessage.put(AttachmentDeserializer.ATTACHMENT_MAX_HEADER_SIZE,
+                m.getExchange().getInMessage().get(AttachmentDeserializer.ATTACHMENT_MAX_HEADER_SIZE));
+            inMessage.setContent(InputStream.class,
                 m.getExchange().getInMessage().get("org.apache.cxf.multipart.embedded.input"));
-            inMessage.put(Message.CONTENT_TYPE, 
+            inMessage.put(Message.CONTENT_TYPE,
                 m.getExchange().getInMessage().get("org.apache.cxf.multipart.embedded.ctype").toString());
         }
-        
-        
+
+
         new AttachmentInputInterceptor().handleMessage(inMessage);
-    
+
         List<Attachment> newAttachments = new LinkedList<Attachment>();
         try {
-            Map<String, List<String>> headers 
+            Map<String, List<String>> headers
                 = CastUtils.cast((Map<?, ?>)inMessage.get(AttachmentDeserializer.ATTACHMENT_PART_HEADERS));
+
             Attachment first = new Attachment(AttachmentUtil.createAttachment(
-                                     inMessage.getContent(InputStream.class), 
+                                     inMessage.getContent(InputStream.class),
                                      headers),
                                      new ProvidersImpl(inMessage));
             newAttachments.add(first);
         } catch (IOException ex) {
             throw new WebApplicationException(500);
         }
-        
-    
+
+
         Collection<org.apache.cxf.message.Attachment> childAttachments = inMessage.getAttachments();
         if (childAttachments == null) {
             childAttachments = Collections.emptyList();
@@ -300,12 +306,12 @@ public class MessageContextImpl implements MessageContext {
         for (org.apache.cxf.message.Attachment a : childAttachments) {
             newAttachments.add(new Attachment(a, new ProvidersImpl(inMessage)));
         }
-        MediaType mt = embeddedAttachment 
+        MediaType mt = embeddedAttachment
             ? (MediaType)inMessage.get("org.apache.cxf.multipart.embedded.ctype")
             : getHttpHeaders().getMediaType();
         MultipartBody body = new MultipartBody(newAttachments, mt, false);
         inMessage.put(propertyName, body);
         return body;
     }
-       
+
 }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/ext/multipart/Attachment.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/ext/multipart/Attachment.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import javax.activation.DataHandler;
 import javax.activation.DataSource;
@@ -39,21 +40,21 @@ import org.apache.cxf.jaxrs.utils.ExceptionUtils;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 
 /**
- * This class represents an attachment; generally a multipart part. 
+ * This class represents an attachment; generally a multipart part.
  * Some constructors in here are intended only for
- * internal use in CXF, others are suitable or preparing 
- * attachments to pass to the {@link org.apache.cxf.jaxrs.client.WebClient} API. 
- * See the {@link AttachmentBuilder} for a convenient 
+ * internal use in CXF, others are suitable or preparing
+ * attachments to pass to the {@link org.apache.cxf.jaxrs.client.WebClient} API.
+ * See the {@link AttachmentBuilder} for a convenient
  * way to create attachments for use with {@link org.apache.cxf.jaxrs.client.WebClient}.
  */
 public class Attachment implements Transferable {
 
     private DataHandler handler;
-    private MultivaluedMap<String, String> headers = 
+    private MultivaluedMap<String, String> headers =
         new MetadataMap<String, String>(false, true);
     private Object object;
     private Providers providers;
-    
+
     public Attachment(org.apache.cxf.message.Attachment a,
                       Providers providers) {
         handler = a.getDataHandler();
@@ -67,34 +68,38 @@ public class Attachment implements Transferable {
         headers.putSingle("Content-ID", a.getId());
         this.providers = providers;
     }
-    
+
     public Attachment(String id, DataHandler dh, MultivaluedMap<String, String> headers) {
         handler = dh;
         this.headers = new MetadataMap<String, String>(headers, false, true);
         this.headers.putSingle("Content-ID", id);
     }
-    
+
     public Attachment(String id, DataSource ds, MultivaluedMap<String, String> headers) {
         this(id, new DataHandler(ds), headers);
     }
-    
+
     public Attachment(MultivaluedMap<String, String> headers, Object object) {
         this.headers = headers;
         this.object = object;
     }
-    
+
     public Attachment(InputStream is, MultivaluedMap<String, String> headers) {
-        this(headers.getFirst("Content-ID"), 
-             new DataHandler(new InputStreamDataSource(is, headers.getFirst("Content-Type"))), 
+        this(headers.getFirst("Content-ID"),
+             new DataHandler(new InputStreamDataSource(is, headers.getFirst("Content-Type"))),
              headers);
     }
-    
+
+    public Attachment(String mediaType, Object object) {
+        this(UUID.randomUUID().toString(), mediaType, object);
+    }
+
     public Attachment(String id, String mediaType, Object object) {
         this.object = object;
         headers.putSingle("Content-ID", id);
         headers.putSingle("Content-Type", mediaType);
     }
-    
+
     public Attachment(String id, InputStream is, ContentDisposition cd) {
         handler = new DataHandler(new InputStreamDataSource(is, "application/octet-stream"));
         if (cd != null) {
@@ -103,16 +108,16 @@ public class Attachment implements Transferable {
         headers.putSingle("Content-ID", id);
         headers.putSingle("Content-Type", "application/octet-stream");
     }
-    
-    Attachment(MultivaluedMap<String, String> headers, DataHandler handler, Object object) {
+
+    public Attachment(MultivaluedMap<String, String> headers, DataHandler handler, Object object) {
         this.headers = headers;
         this.handler = handler;
         this.object = object;
     }
-    
+
     public ContentDisposition getContentDisposition() {
         String header = getHeader("Content-Disposition");
-        
+
         return header == null ? null : new ContentDisposition(header);
     }
 
@@ -121,7 +126,8 @@ public class Attachment implements Transferable {
     }
 
     public MediaType getContentType() {
-        String value = handler != null ? handler.getContentType() : headers.getFirst("Content-Type");
+        String value = handler != null && handler.getContentType() != null ? handler.getContentType()
+            : headers.getFirst("Content-Type");
         return value == null ? MediaType.TEXT_PLAIN_TYPE : JAXRSUtils.toMediaType(value);
     }
 
@@ -132,14 +138,14 @@ public class Attachment implements Transferable {
     public Object getObject() {
         return object;
     }
-    
+
     public <T> T getObject(Class<T> cls) {
         if (providers != null) {
-            MessageBodyReader<T> mbr = 
+            MessageBodyReader<T> mbr =
                 providers.getMessageBodyReader(cls, cls, new Annotation[]{}, getContentType());
             if (mbr != null) {
                 try {
-                    return mbr.readFrom(cls, cls, new Annotation[]{}, getContentType(), 
+                    return mbr.readFrom(cls, cls, new Annotation[]{}, getContentType(),
                                         headers, getDataHandler().getInputStream());
                 } catch (Exception ex) {
                     ExceptionUtils.toInternalServerErrorException(ex, null);
@@ -148,7 +154,7 @@ public class Attachment implements Transferable {
         }
         return null;
     }
-    
+
     public String getHeader(String name) {
         List<String> header = headers.get(name);
         if (header == null || header.size() == 0) {
@@ -163,7 +169,7 @@ public class Attachment implements Transferable {
         }
         return sb.toString();
     }
-    
+
     public List<String> getHeaderAsList(String name) {
         return headers.get(name);
     }
@@ -171,25 +177,25 @@ public class Attachment implements Transferable {
     public MultivaluedMap<String, String> getHeaders() {
         return new MetadataMap<String, String>(headers, false, true);
     }
-    
+
     public void transferTo(File destinationFile) throws IOException {
         IOUtils.transferTo(handler.getInputStream(), destinationFile);
     }
 
     @Override
     public int hashCode() {
-        return headers.hashCode(); 
+        return headers.hashCode();
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Attachment)) { 
+        if (!(o instanceof Attachment)) {
             return false;
         }
-        
+
         Attachment other = (Attachment)o;
         return headers.equals(other.headers);
     }
-    
+
 
 }

--- a/rt/frontend/jaxws/pom.xml
+++ b/rt/frontend/jaxws/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/frontend/js/pom.xml
+++ b/rt/frontend/js/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/frontend/pom.xml
+++ b/rt/frontend/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>simple</module>

--- a/rt/frontend/simple/pom.xml
+++ b/rt/frontend/simple/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/javascript/javascript-rt/pom.xml
+++ b/rt/javascript/javascript-rt/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-runtime-javascript</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/rt/javascript/javascript-tests/pom.xml
+++ b/rt/javascript/javascript-tests/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-runtime-javascript</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/rt/javascript/pom.xml
+++ b/rt/javascript/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modules>

--- a/rt/management-web/pom.xml
+++ b/rt/management-web/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/management/pom.xml
+++ b/rt/management/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/pom.xml
+++ b/rt/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>wsdl</module>

--- a/rt/rs/client/pom.xml
+++ b/rt/rs/client/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/rs/description/pom.xml
+++ b/rt/rs/description/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/rs/extensions/json-basic/pom.xml
+++ b/rt/rs/extensions/json-basic/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/rs/extensions/providers/pom.xml
+++ b/rt/rs/extensions/providers/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/rs/extensions/providers/src/main/java/org/apache/cxf/jaxrs/provider/atom/AbstractAtomProvider.java
+++ b/rt/rs/extensions/providers/src/main/java/org/apache/cxf/jaxrs/provider/atom/AbstractAtomProvider.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
+import javax.xml.stream.XMLStreamReader;
 
 import org.apache.abdera.Abdera;
 import org.apache.abdera.model.Document;
@@ -39,6 +40,7 @@ import org.apache.abdera.parser.ParserOptions;
 import org.apache.abdera.writer.Writer;
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.jaxrs.utils.ExceptionUtils;
+import org.apache.cxf.staxutils.StaxUtils;
 
 public abstract class AbstractAtomProvider<T extends Element> 
     implements MessageBodyWriter<T>, MessageBodyReader<T> {
@@ -91,7 +93,8 @@ public abstract class AbstractAtomProvider<T extends Element>
                 options.setAutodetectCharset(autodetectCharset);
             }
         }
-        Document<T> doc = parser.parse(is);
+        XMLStreamReader reader = StaxUtils.createXMLStreamReader(is);
+        Document<T> doc = parser.parse(reader);
         return doc.getRoot();
     }
 

--- a/rt/rs/extensions/providers/src/test/java/org/apache/cxf/jaxrs/provider/atom/AtomPojoProviderTest.java
+++ b/rt/rs/extensions/providers/src/test/java/org/apache/cxf/jaxrs/provider/atom/AtomPojoProviderTest.java
@@ -145,6 +145,25 @@ public class AtomPojoProviderTest extends Assert {
                                             new Annotation[]{}, mt, null, bis);
         assertEquals("a", book.getName());
     }
+    @Test
+    public void testReadEntryNoBuilders2() throws Exception {
+        final String entry = 
+            "<!DOCTYPE entry SYSTEM \"entry://entry\"><entry xmlns=\"http://www.w3.org/2005/Atom\">"
+            + "<title type=\"text\">a</title>"
+            + "<content type=\"application/xml\">"
+            + "<book xmlns=\"\">"
+            + "<name>a</name>"
+            + "</book>"
+            + "</content>"
+            + "</entry>";
+        AtomPojoProvider provider = new AtomPojoProvider();
+        ByteArrayInputStream bis = new ByteArrayInputStream(entry.getBytes());
+        MediaType mt = MediaType.valueOf("application/atom+xml;type=entry");
+        @SuppressWarnings({"unchecked", "rawtypes" })
+        Book book = (Book)provider.readFrom((Class)Book.class, Book.class, 
+                                            new Annotation[]{}, mt, null, bis);
+        assertEquals("a", book.getName());
+    }
     
     
     @Test
@@ -179,6 +198,24 @@ public class AtomPojoProviderTest extends Assert {
         assertTrue("b".equals(list.get(0).getName()) || "b".equals(list.get(1).getName()));        
     }
      
+    @Test
+    public void testReadFeedWithoutBuilders2() throws Exception {
+        AtomPojoProvider provider = new AtomPojoProvider();
+        final String feed = 
+            "<!DOCTYPE feed SYSTEM \"feed://feed\"><feed xmlns=\"http://www.w3.org/2005/Atom\">"
+            + "<entry><content type=\"application/xml\"><book xmlns=\"\"><name>a</name></book></content></entry>"
+            + "<entry><content type=\"application/xml\"><book xmlns=\"\"><name>b</name></book></content></entry>"
+            + "</feed>";
+        MediaType mt = MediaType.valueOf("application/atom+xml;type=feed");
+        ByteArrayInputStream bis = new ByteArrayInputStream(feed.getBytes());
+        @SuppressWarnings({"unchecked", "rawtypes" })
+        Books books2 = (Books)provider.readFrom((Class)Books.class, Books.class, 
+                                            new Annotation[]{}, mt, null, bis);
+        List<Book> list = books2.getBooks();
+        assertEquals(2, list.size());
+        assertTrue("a".equals(list.get(0).getName()) || "a".equals(list.get(1).getName()));
+        assertTrue("b".equals(list.get(0).getName()) || "b".equals(list.get(1).getName()));
+    }
     @Test
     public void testReadEntryNoContent() throws Exception {
         /** A sample entry without content. */

--- a/rt/rs/extensions/search/pom.xml
+++ b/rt/rs/extensions/search/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/rs/http-sci/pom.xml
+++ b/rt/rs/http-sci/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/rs/pom.xml
+++ b/rt/rs/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>client</module>

--- a/rt/rs/security/cors/pom.xml
+++ b/rt/rs/security/cors/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/rs/security/jose-parent/jose-jaxrs/pom.xml
+++ b/rt/rs/security/jose-parent/jose-jaxrs/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/rs/security/jose-parent/jose/pom.xml
+++ b/rt/rs/security/jose-parent/jose/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/jwe/AesCbcHmacJweDecryption.java
+++ b/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/jwe/AesCbcHmacJweDecryption.java
@@ -18,8 +18,8 @@
  */
 package org.apache.cxf.rs.security.jose.jwe;
 
+import java.security.MessageDigest;
 import java.security.spec.AlgorithmParameterSpec;
-import java.util.Arrays;
 
 import javax.crypto.spec.IvParameterSpec;
 
@@ -56,7 +56,7 @@ public class AesCbcHmacJweDecryption extends JweDecryption {
                                                            jweDecryptionInput.getDecodedJsonHeaders());
         macState.mac.update(jweDecryptionInput.getEncryptedContent());
         byte[] expectedAuthTag = AesCbcHmacJweEncryption.signAndGetTag(macState);
-        if (!Arrays.equals(actualAuthTag, expectedAuthTag)) {
+        if (!MessageDigest.isEqual(actualAuthTag, expectedAuthTag)) {
             LOG.warning("Invalid authentication tag");
             throw new JweException(JweException.Error.CONTENT_DECRYPTION_FAILURE);
         }

--- a/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/jws/HmacJwsSignatureVerifier.java
+++ b/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/jws/HmacJwsSignatureVerifier.java
@@ -18,8 +18,8 @@
  */
 package org.apache.cxf.rs.security.jose.jws;
 
+import java.security.MessageDigest;
 import java.security.spec.AlgorithmParameterSpec;
-import java.util.Arrays;
 import java.util.logging.Logger;
 
 import org.apache.cxf.common.logging.LogUtils;
@@ -53,7 +53,7 @@ public class HmacJwsSignatureVerifier implements JwsSignatureVerifier {
     @Override
     public boolean verify(JwsHeaders headers, String unsignedText, byte[] signature) {
         byte[] expected = computeMac(headers, unsignedText);
-        return Arrays.equals(expected, signature);
+        return MessageDigest.isEqual(expected, signature);
     }
     
     private byte[] computeMac(JwsHeaders headers, String text) {

--- a/rt/rs/security/jose-parent/pom.xml
+++ b/rt/rs/security/jose-parent/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-security</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>jose</module>

--- a/rt/rs/security/oauth-parent/oauth/pom.xml
+++ b/rt/rs/security/oauth-parent/oauth/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>cxf-rt-rs-security-oauth-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/rs/security/oauth-parent/oauth2-saml/pom.xml
+++ b/rt/rs/security/oauth-parent/oauth2-saml/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>cxf-rt-rs-security-oauth-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/rs/security/oauth-parent/oauth2/pom.xml
+++ b/rt/rs/security/oauth-parent/oauth2/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>cxf-rt-rs-security-oauth-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/tokens/hawk/AbstractHawkAccessTokenValidator.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/tokens/hawk/AbstractHawkAccessTokenValidator.java
@@ -19,7 +19,7 @@
 package org.apache.cxf.rs.security.oauth2.tokens.hawk;
 
 import java.net.URI;
-import java.util.Arrays;
+import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -78,7 +78,7 @@ public abstract class AbstractHawkAccessTokenValidator implements AccessTokenVal
                                                          
             String clientMacString = schemeParams.get(OAuthConstants.HAWK_TOKEN_SIGNATURE);
             byte[] clientMacData = Base64Utility.decode(clientMacString);
-            boolean validMac = Arrays.equals(serverMacData, clientMacData);
+            boolean validMac = MessageDigest.isEqual(serverMacData, clientMacData);
             if (!validMac) {
                 AuthorizationUtils.throwAuthorizationFailure(Collections
                     .singleton(OAuthConstants.HAWK_AUTHORIZATION_SCHEME));

--- a/rt/rs/security/oauth-parent/pom.xml
+++ b/rt/rs/security/oauth-parent/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/rs/security/pom.xml
+++ b/rt/rs/security/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>xml</module>

--- a/rt/rs/security/sso/oidc/pom.xml
+++ b/rt/rs/security/sso/oidc/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/rs/security/sso/saml/pom.xml
+++ b/rt/rs/security/sso/saml/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/rs/security/xml/pom.xml
+++ b/rt/rs/security/xml/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/security-saml/pom.xml
+++ b/rt/security-saml/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/security/pom.xml
+++ b/rt/security/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/transports/http-hc/pom.xml
+++ b/rt/transports/http-hc/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/transports/http-jetty/pom.xml
+++ b/rt/transports/http-jetty/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/transports/http-netty/netty-client/pom.xml
+++ b/rt/transports/http-netty/netty-client/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/transports/http-netty/netty-server/pom.xml
+++ b/rt/transports/http-netty/netty-server/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/transports/http/pom.xml
+++ b/rt/transports/http/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/https/HttpsURLConnectionFactory.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/https/HttpsURLConnectionFactory.java
@@ -193,7 +193,7 @@ public class HttpsURLConnectionFactory {
                         try {
                             return super.invoke(proxy, method, args);
                         } catch (Exception ex) {
-                            return true;
+                            return false;
                         }
                     }
                 };

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/https/httpclient/DefaultHostnameVerifier.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/https/httpclient/DefaultHostnameVerifier.java
@@ -130,6 +130,18 @@ public final class DefaultHostnameVerifier implements HostnameVerifier {
         }
     }
 
+    public boolean verify(final String host, final String certHostname) {
+        try {
+            matchCN(host, certHostname, this.publicSuffixMatcher);
+            return true;
+        } catch (SSLException ex) {
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.log(Level.FINE, ex.getMessage(), ex);
+            }
+            return false;
+        }
+    }
+
     static void matchIPAddress(final String host, final List<String> subjectAlts) throws SSLException {
         for (int i = 0; i < subjectAlts.size(); i++) {
             final String subjectAlt = subjectAlts.get(i);

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/BaseUrlHelper.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/BaseUrlHelper.java
@@ -36,9 +36,8 @@ public final class BaseUrlHelper {
      */
     public static String getBaseURL(HttpServletRequest request) {
         String reqPrefix = request.getRequestURL().toString();        
-        String pathInfo = request.getPathInfo() == null ? "" : request.getPathInfo();
-        //fix for CXF-898
-        if (!"/".equals(pathInfo) || reqPrefix.endsWith("/")) {
+        String pathInfo = request.getPathInfo();
+        if (!"/".equals(pathInfo) || reqPrefix.contains(";")) {
             StringBuilder sb = new StringBuilder();
             // request.getScheme(), request.getLocalName() and request.getLocalPort()
             // should be marginally cheaper - provided request.getLocalName() does 
@@ -47,14 +46,16 @@ public final class BaseUrlHelper {
             
             URI uri = URI.create(reqPrefix);
             sb.append(uri.getScheme()).append("://").append(uri.getRawAuthority());
-            sb.append(request.getContextPath()).append(request.getServletPath());
+            String contextPath = request.getContextPath();
+            if (contextPath != null) {
+                sb.append(contextPath);
+            }
+            String servletPath = request.getServletPath();
+            if (servletPath != null) {
+                sb.append(servletPath);
+            }
             
             reqPrefix = sb.toString();
-        } else {
-            int matrixParamIndex = reqPrefix.indexOf(";");
-            if (matrixParamIndex > 0) {
-                reqPrefix = reqPrefix.substring(0, matrixParamIndex);
-            }
         }
         return reqPrefix;
     }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/BaseUrlHelper.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/BaseUrlHelper.java
@@ -50,6 +50,11 @@ public final class BaseUrlHelper {
             sb.append(request.getContextPath()).append(request.getServletPath());
             
             reqPrefix = sb.toString();
+        } else {
+            int matrixParamIndex = reqPrefix.indexOf(";");
+            if (matrixParamIndex > 0) {
+                reqPrefix = reqPrefix.substring(0, matrixParamIndex);
+            }
         }
         return reqPrefix;
     }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/servicelist/FormattedServiceListWriter.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/servicelist/FormattedServiceListWriter.java
@@ -129,7 +129,11 @@ public class FormattedServiceListWriter implements ServiceListWriter {
                 return null;
             }
         } else {
-            return basePath + endpointAddress;
+            String address = basePath;
+            if (address.endsWith("/") && endpointAddress.startsWith("/")) { 
+                address = address.substring(0, address.length() - 1);
+            }
+            return address + endpointAddress;
         }
     }
     

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/servicelist/ServiceListGeneratorServlet.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/servicelist/ServiceListGeneratorServlet.java
@@ -112,12 +112,20 @@ public class ServiceListGeneratorServlet extends HttpServlet {
             if (serviceListStyleSheet != null) {
                 styleSheetPath = request.getContextPath() + "/" + serviceListStyleSheet;
             } else {
-                String requestUri = request.getRequestURI();
-                int matrixParamIndex = requestUri.indexOf(";");
-                if (matrixParamIndex > 0) {
-                    requestUri = requestUri.substring(0, matrixParamIndex);
+                styleSheetPath = "";
+                String contextPath = request.getContextPath();
+                if (contextPath != null) {
+                    styleSheetPath += contextPath;
                 }
-                styleSheetPath = requestUri;
+                String servletPath = request.getServletPath();
+                if (servletPath != null) {
+                    styleSheetPath += servletPath;
+                }
+                String pathInfo = request.getPathInfo();
+                if (pathInfo != null) {
+                    styleSheetPath += pathInfo;
+                }
+                
                 if (!styleSheetPath.endsWith("/")) {
                     styleSheetPath += "/";
                 }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/servicelist/ServiceListGeneratorServlet.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/servicelist/ServiceListGeneratorServlet.java
@@ -111,9 +111,17 @@ public class ServiceListGeneratorServlet extends HttpServlet {
             String styleSheetPath;
             if (serviceListStyleSheet != null) {
                 styleSheetPath = request.getContextPath() + "/" + serviceListStyleSheet;
-                
             } else {
-                styleSheetPath = request.getRequestURI() + "/?stylesheet=1";
+                String requestUri = request.getRequestURI();
+                int matrixParamIndex = requestUri.indexOf(";");
+                if (matrixParamIndex > 0) {
+                    requestUri = requestUri.substring(0, matrixParamIndex);
+                }
+                styleSheetPath = requestUri;
+                if (!styleSheetPath.endsWith("/")) {
+                    styleSheetPath += "/";
+                }
+                styleSheetPath += "?stylesheet=1";
             }
             serviceListWriter = 
                 new FormattedServiceListWriter(styleSheetPath, title, showForeignContexts, atomMap);

--- a/rt/transports/jms/pom.xml
+++ b/rt/transports/jms/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/transports/local/pom.xml
+++ b/rt/transports/local/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/transports/pom.xml
+++ b/rt/transports/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>local</module>

--- a/rt/transports/udp/pom.xml
+++ b/rt/transports/udp/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/transports/udp/src/test/java/org/apache/cxf/transport/udp/UDPTransportTest.java
+++ b/rt/transports/udp/src/test/java/org/apache/cxf/transport/udp/UDPTransportTest.java
@@ -31,11 +31,13 @@ import org.apache.hello_world.GreeterImpl;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * 
  */
+@Ignore
 public class UDPTransportTest extends AbstractBusClientServerTestBase {
     static final String PORT = allocatePort(UDPTransportTest.class);
     private static Server server; 

--- a/rt/transports/websocket/pom.xml
+++ b/rt/transports/websocket/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/ws/addr/pom.xml
+++ b/rt/ws/addr/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/ws/eventing/pom.xml
+++ b/rt/ws/eventing/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/ws/mex/pom.xml
+++ b/rt/ws/mex/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/rt/ws/policy/pom.xml
+++ b/rt/ws/policy/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/ws/pom.xml
+++ b/rt/ws/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>policy</module>

--- a/rt/ws/rm/pom.xml
+++ b/rt/ws/rm/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/ws/security/pom.xml
+++ b/rt/ws/security/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/STSTokenRetriever.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/STSTokenRetriever.java
@@ -19,6 +19,8 @@
 
 package org.apache.cxf.ws.security.trust;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -27,6 +29,7 @@ import java.util.logging.Logger;
 import org.w3c.dom.Element;
 
 import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.common.util.Base64Utility;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.rt.security.utils.SecurityUtils;
@@ -37,6 +40,7 @@ import org.apache.cxf.ws.security.tokenstore.TokenStore;
 import org.apache.cxf.ws.security.tokenstore.TokenStoreUtils;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.SamlAssertionWrapper;
+import org.apache.wss4j.common.util.XMLUtils;
 import org.apache.wss4j.dom.WSConstants;
 import org.apache.wss4j.policy.model.Trust10;
 import org.apache.wss4j.policy.model.Trust13;
@@ -348,15 +352,41 @@ public final class STSTokenRetriever {
         return null;
     }
 
+    // Get an id from the token that is unique to that token
     private static String getIdFromToken(Element token) {
         if (token != null) {
-            // Try to find the "Id" on the token.
-            if (token.hasAttributeNS(WSConstants.WSU_NS, "Id")) {
-                return token.getAttributeNS(WSConstants.WSU_NS, "Id");
-            } else if (token.hasAttributeNS(null, "ID")) {
+            // For SAML tokens get the ID/AssertionID
+            if ("Assertion".equals(token.getLocalName())
+                    && WSConstants.SAML2_NS.equals(token.getNamespaceURI())) {
                 return token.getAttributeNS(null, "ID");
-            } else if (token.hasAttributeNS(null, "AssertionID")) {
+            } else if ("Assertion".equals(token.getLocalName())
+                    && WSConstants.SAML_NS.equals(token.getNamespaceURI())) {
                 return token.getAttributeNS(null, "AssertionID");
+            }
+
+            // For UsernameTokens get the username
+            if (WSConstants.USERNAME_TOKEN_LN.equals(token.getLocalName())
+                    && WSConstants.WSSE_NS.equals(token.getNamespaceURI())) {
+                Element usernameElement =
+                        XMLUtils.getDirectChildElement(token, WSConstants.USERNAME_LN, WSConstants.WSSE_NS);
+                if (usernameElement != null) {
+                    return XMLUtils.getElementText(usernameElement);
+                }
+            }
+
+            // For BinarySecurityTokens take the hash of the value
+            if (WSConstants.BINARY_TOKEN_LN.equals(token.getLocalName())
+                    && WSConstants.WSSE_NS.equals(token.getNamespaceURI())) {
+                String text = XMLUtils.getElementText(token);
+                if (text != null && !"".equals(text)) {
+                    try {
+                        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                        byte[] bytes = digest.digest(text.getBytes());
+                        return Base64Utility.encode(bytes);
+                    } catch (NoSuchAlgorithmException e) {
+                        // SHA-256 must be supported so not going to happen...
+                    }
+                }
             }
         }
         return "";

--- a/rt/wsdl/pom.xml
+++ b/rt/wsdl/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -28,7 +28,7 @@
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>sts</module>

--- a/services/sts/pom.xml
+++ b/services/sts/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.services</groupId>
         <artifactId>cxf-services</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modules>

--- a/services/sts/sts-core/pom.xml
+++ b/services/sts/sts-core/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/sts/sts-war/pom.xml
+++ b/services/sts/sts-war/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/sts/systests/advanced/pom.xml
+++ b/services/sts/systests/advanced/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/sts/systests/basic/pom.xml
+++ b/services/sts/systests/basic/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/sts/systests/pom.xml
+++ b/services/sts/systests/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.services.sts</groupId>
         <artifactId>cxf-services-sts</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>basic</module>

--- a/services/sts/systests/sts-features/pom.xml
+++ b/services/sts/systests/sts-features/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <build>

--- a/services/sts/systests/sts-itests/pom.xml
+++ b/services/sts/systests/sts-itests/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/sts/systests/sts-osgi/pom.xml
+++ b/services/sts/systests/sts-osgi/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/ws-discovery/pom.xml
+++ b/services/ws-discovery/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.services</groupId>
         <artifactId>cxf-services</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modules>

--- a/services/ws-discovery/ws-discovery-api/pom.xml
+++ b/services/ws-discovery/ws-discovery-api/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/services/ws-discovery/ws-discovery-api/src/test/java/org/apache/cxf/ws/discovery/WSDiscoveryClientTest.java
+++ b/services/ws-discovery/ws-discovery-api/src/test/java/org/apache/cxf/ws/discovery/WSDiscoveryClientTest.java
@@ -50,12 +50,14 @@ import org.apache.cxf.ws.discovery.wsdl.ResolveMatchType;
 import org.apache.cxf.ws.discovery.wsdl.ScopesType;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 
 /**
  * 
  */
+@Ignore
 public final class WSDiscoveryClientTest {
     public static final String PORT = TestUtil.getPortNumber(WSDiscoveryClientTest.class);
    

--- a/services/ws-discovery/ws-discovery-service/pom.xml
+++ b/services/ws-discovery/ws-discovery-service/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/services/wsn/pom.xml
+++ b/services/wsn/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.services</groupId>
         <artifactId>cxf-services</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modules>

--- a/services/wsn/wsn-api/pom.xml
+++ b/services/wsn/wsn-api/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/wsn/wsn-core/pom.xml
+++ b/services/wsn/wsn-core/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/services/wsn/wsn-osgi/pom.xml
+++ b/services/wsn/wsn-osgi/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/xkms/pom.xml
+++ b/services/xkms/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.cxf.services</groupId>
         <artifactId>cxf-services</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modules>

--- a/services/xkms/xkms-client/pom.xml
+++ b/services/xkms/xkms-client/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <build>

--- a/services/xkms/xkms-common/pom.xml
+++ b/services/xkms/xkms-common/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/xkms/xkms-features/pom.xml
+++ b/services/xkms/xkms-features/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <build>

--- a/services/xkms/xkms-itests/pom.xml
+++ b/services/xkms/xkms-itests/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/xkms/xkms-osgi/pom.xml
+++ b/services/xkms/xkms-osgi/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/xkms/xkms-service/pom.xml
+++ b/services/xkms/xkms-service/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/xkms/xkms-war/pom.xml
+++ b/services/xkms/xkms-war/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/xkms/xkms-x509-handlers/pom.xml
+++ b/services/xkms/xkms-x509-handlers/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/xkms/xkms-x509-repo-ldap/pom.xml
+++ b/services/xkms/xkms-x509-repo-ldap/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <groupId>org.apache.cxf.services.xkms</groupId>

--- a/systests/cdi/pom.xml
+++ b/systests/cdi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/container-integration/grizzly/pom.xml
+++ b/systests/container-integration/grizzly/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.cxf.systests</groupId>
         <artifactId>cxf-systests-container-integration</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cxf-systests-ci-grizzly</artifactId>

--- a/systests/container-integration/pom.xml
+++ b/systests/container-integration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/container-integration/webapp/pom.xml
+++ b/systests/container-integration/webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.cxf.systests</groupId>
         <artifactId>cxf-systests-container-integration</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cxf-systests-ci-webapp</artifactId>

--- a/systests/databinding/pom.xml
+++ b/systests/databinding/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/jaxrs/pom.xml
+++ b/systests/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerSpringBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerSpringBookTest.java
@@ -82,7 +82,6 @@ public class JAXRSClientServerSpringBookTest extends AbstractBusClientServerTest
     public void testGetGenericBook() throws Exception {
         String baseAddress = "http://localhost:" + PORT + "/the/thebooks8/books"; 
         WebClient wc = WebClient.create(baseAddress);
-        WebClient.getConfig(wc).getHttpConduit().getClient().setReceiveTimeout(10000000);
         Long id = wc.type("application/xml").accept("text/plain").post(new Book("CXF", 1L), Long.class);
         assertEquals(new Long(1), id);
         Book book = wc.replaceHeader("Accept", "application/xml").query("id", 1L).get(Book.class);
@@ -100,8 +99,36 @@ public class JAXRSClientServerSpringBookTest extends AbstractBusClientServerTest
     public void testGetBookText() throws Exception {
         final String address = "http://localhost:" + PORT + "/the/thebooks/bookstore/books/text"; 
         WebClient wc = WebClient.create(address).accept("text/*");
+        WebClient.getConfig(wc).getHttpConduit().getClient().setReceiveTimeout(10000000);
         assertEquals(406, wc.get().getStatus());
         
+    }
+    
+    @Test
+    public void testGetServicesPageNotFound() throws Exception {
+        final String address = "http://localhost:" + PORT + "/the/services;a=b"; 
+        WebClient wc = WebClient.create(address).accept("text/*");
+        WebClient.getConfig(wc).getHttpConduit().getClient().setReceiveTimeout(10000000);
+        assertEquals(404, wc.get().getStatus());
+    }
+    @Test
+    public void testGetServicesPage() throws Exception {
+        final String address = "http://localhost:" + PORT + "/the/services"; 
+        WebClient wc = WebClient.create(address).accept("text/*");
+        String s = wc.get(String.class);
+        assertTrue(s.contains("href=\"/the/services/?stylesheet=1\""));
+        assertTrue(s.contains("<title>CXF - Service list</title>"));
+        assertTrue(s.contains("<a href=\"http://localhost:" + PORT + "/the/"));
+    }
+    @Test
+    public void testGetServicesPageWithServletPatternMatchOnly() throws Exception {
+        final String address = "http://localhost:" + PORT + "/the/;a=b"; 
+        WebClient wc = WebClient.create(address).accept("text/*");
+        String s = wc.get(String.class);
+        assertTrue(s.contains("href=\"/the/?stylesheet=1\""));
+        assertTrue(s.contains("<title>CXF - Service list</title>"));
+        assertFalse(s.contains(";a=b"));
+        assertTrue(s.contains("<a href=\"http://localhost:" + PORT + "/the/"));
     }
     
     @Test

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerSpringBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerSpringBookTest.java
@@ -130,6 +130,16 @@ public class JAXRSClientServerSpringBookTest extends AbstractBusClientServerTest
         assertFalse(s.contains(";a=b"));
         assertTrue(s.contains("<a href=\"http://localhost:" + PORT + "/the/"));
     }
+    @Test
+    public void testGetServicesPageWithServletPatternMatchOnly2() throws Exception {
+        final String address = "http://localhost:" + PORT + "/services;a=b;/list;a=b/;a=b"; 
+        WebClient wc = WebClient.create(address).accept("text/*");
+        String s = wc.get(String.class);
+        assertTrue(s.contains("href=\"/services/list/?stylesheet=1\""));
+        assertTrue(s.contains("<title>CXF - Service list</title>"));
+        assertFalse(s.contains(";a=b"));
+        assertTrue(s.contains("<a href=\"http://localhost:" + PORT + "/services/list/"));
+    }
     
     @Test
     public void testEchoBookForm() throws Exception {

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerSpringBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerSpringBookTest.java
@@ -132,7 +132,7 @@ public class JAXRSClientServerSpringBookTest extends AbstractBusClientServerTest
     }
     @Test
     public void testGetServicesPageWithServletPatternMatchOnly2() throws Exception {
-        final String address = "http://localhost:" + PORT + "/services;a=b;/list;a=b/;a=b"; 
+        final String address = "http://localhost:" + PORT + "/services/list/;a=b"; 
         WebClient wc = WebClient.create(address).accept("text/*");
         String s = wc.get(String.class);
         assertTrue(s.contains("href=\"/services/list/?stylesheet=1\""));

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/MultipartServer.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/MultipartServer.java
@@ -40,6 +40,7 @@ public class MultipartServer extends AbstractBusTestServerBase {
         Map<String, Object> props = new HashMap<String, Object>();
         props.put(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, String.valueOf(1024 * 10));
         props.put(AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, String.valueOf(1024 * 5));
+        props.put(AttachmentDeserializer.ATTACHMENT_MAX_HEADER_SIZE, String.valueOf(400));
         sf.setProperties(props);
         //default lifecycle is per-request, change it to singleton
         sf.setResourceProvider(MultipartStore.class,

--- a/systests/jaxrs/src/test/resources/jaxrs/WEB-INF/web.xml
+++ b/systests/jaxrs/src/test/resources/jaxrs/WEB-INF/web.xml
@@ -51,6 +51,14 @@
         </init-param>        
         <load-on-startup>1</load-on-startup>
     </servlet>
+    <servlet>
+        <servlet-name>CXFServlet3</servlet-name>
+        <display-name>CXF Servlet3</display-name>
+        <servlet-class>
+                        org.apache.cxf.transport.servlet.CXFServlet
+                </servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
     <servlet-mapping>
         <servlet-name>CXFServlet</servlet-name>
         <url-pattern>/the/*</url-pattern>
@@ -58,6 +66,10 @@
     <servlet-mapping>
         <servlet-name>CXFServlet2</servlet-name>
         <url-pattern>/bus/*</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>CXFServlet3</servlet-name>
+        <url-pattern>/services/list/*</url-pattern>
     </servlet-mapping>
 </web-app>
 <!-- END SNIPPET: webxml -->

--- a/systests/jaxws/pom.xml
+++ b/systests/jaxws/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/jibx/databinding-jibx/pom.xml
+++ b/systests/jibx/databinding-jibx/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-systests-jibx</artifactId>
         <groupId>org.apache.cxf.systests</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/jibx/jaxrs-jibx/pom.xml
+++ b/systests/jibx/jaxrs-jibx/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-systests-jibx</artifactId>
         <groupId>org.apache.cxf.systests</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/jibx/pom.xml
+++ b/systests/jibx/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/kerberos/pom.xml
+++ b/systests/kerberos/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/pom.xml
+++ b/systests/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>container-integration</module>

--- a/systests/rs-http-sci/pom.xml
+++ b/systests/rs-http-sci/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/rs-security/pom.xml
+++ b/systests/rs-security/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/tracing/pom.xml
+++ b/systests/tracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/transport-jms/pom.xml
+++ b/systests/transport-jms/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/transports-ssl3/pom.xml
+++ b/systests/transports-ssl3/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/transports/pom.xml
+++ b/systests/transports/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/transports/src/test/java/org/apache/cxf/systest/https/hostname/HostnameVerificationDeprecatedServer.java
+++ b/systests/transports/src/test/java/org/apache/cxf/systest/https/hostname/HostnameVerificationDeprecatedServer.java
@@ -16,31 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
- 
-package org.apache.cxf.transport.https;
 
-import java.security.cert.Certificate;
-import java.security.cert.X509Certificate;
+package org.apache.cxf.systest.https.hostname;
 
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSession;
+import java.net.URL;
 
-/**
- * Allow all hostnames. This is only suitable for use in testing, and NOT in production! 
- */
-class AllowAllHostnameVerifier implements javax.net.ssl.HostnameVerifier {
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.bus.spring.SpringBusFactory;
+import org.apache.cxf.testutil.common.AbstractBusTestServerBase;
 
-    @Override
-    public boolean verify(String host, SSLSession session) {
-        try {
-            Certificate[] certs = session.getPeerCertificates();
-            return certs != null && certs[0] instanceof X509Certificate;
-        } catch (SSLException e) {
-            return false;
-        }
+public class HostnameVerificationDeprecatedServer extends AbstractBusTestServerBase {
+
+    public HostnameVerificationDeprecatedServer() {
+
     }
 
-    public boolean verify(final String host, final String certHostname) {
-        return certHostname != null && !certHostname.isEmpty();
+    protected void run()  {
+        URL busFile = HostnameVerificationDeprecatedServer.class.getResource("hostname-server-bethal.xml");
+        Bus busLocal = new SpringBusFactory().createBus(busFile);
+        BusFactory.setDefaultBus(busLocal);
+        setBus(busLocal);
+
+        try {
+            new HostnameVerificationDeprecatedServer();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/systests/transports/src/test/java/org/apache/cxf/systest/https/hostname/HostnameVerificationDeprecatedTest.java
+++ b/systests/transports/src/test/java/org/apache/cxf/systest/https/hostname/HostnameVerificationDeprecatedTest.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.https.hostname;
+
+import java.net.URL;
+
+import javax.xml.ws.BindingProvider;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.bus.spring.SpringBusFactory;
+import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
+import org.apache.hello_world.Greeter;
+import org.apache.hello_world.services.SOAPService;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * A test for hostname verification when the Java system property "java.protocol.handler.pkgs" is set to 
+ * "com.sun.net.ssl.internal.www.protocol". This means that com.sun.net.ssl.HostnameVerifier is used 
+ * instead of the javax version.
+ */
+public class HostnameVerificationDeprecatedTest extends AbstractBusClientServerTestBase {
+    static final String PORT = allocatePort(HostnameVerificationDeprecatedServer.class);
+    static final String PORT2 = allocatePort(HostnameVerificationDeprecatedServer.class, 2);
+
+    @BeforeClass
+    public static void startServers() throws Exception {
+        System.setProperty("java.protocol.handler.pkgs", "com.sun.net.ssl.internal.www.protocol");
+        assertTrue(
+            "Server failed to launch",
+            // run the server in the same process
+            // set this to false to fork
+            launchServer(HostnameVerificationDeprecatedServer.class, true)
+        );
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        System.clearProperty("java.protocol.handler.pkgs");
+        stopAllServers();
+    }
+
+    // Here we expect an exception, as the default hostname verifier contributed by CXF will object to the
+    // fact that the server certificate does not have "CN=localhost".
+    @org.junit.Test
+    public void testLocalhostNotMatching() throws Exception {
+        SpringBusFactory bf = new SpringBusFactory();
+        URL busFile = HostnameVerificationDeprecatedTest.class.getResource("hostname-client-bethal.xml");
+
+        Bus bus = bf.createBus(busFile.toString());
+        BusFactory.setDefaultBus(bus);
+        BusFactory.setThreadDefaultBus(bus);
+
+        URL url = SOAPService.WSDL_LOCATION;
+        SOAPService service = new SOAPService(url, SOAPService.SERVICE);
+        assertNotNull("Service is null", service);
+        final Greeter port = service.getHttpsPort();
+        assertNotNull("Port is null", port);
+
+        updateAddressPort(port, PORT);
+        
+        try {
+            port.greetMe("Kitty");
+            fail("Failure expected on the hostname verification");
+        } catch (Exception ex) {
+            // expected
+        }
+
+        ((java.io.Closeable)port).close();
+        bus.shutdown(true);
+    }
+    
+    // No Subject Alternative Name, but the CN matches ("localhost"), so the default HostnameVerifier
+    // should work fine
+    @org.junit.Test
+    public void testNoSubjectAlternativeNameCNMatch() throws Exception {
+        SpringBusFactory bf = new SpringBusFactory();
+        URL busFile = HostnameVerificationDeprecatedTest.class.getResource("hostname-client.xml");
+
+        Bus bus = bf.createBus(busFile.toString());
+        BusFactory.setDefaultBus(bus);
+        BusFactory.setThreadDefaultBus(bus);
+
+        URL url = SOAPService.WSDL_LOCATION;
+        SOAPService service = new SOAPService(url, SOAPService.SERVICE);
+        assertNotNull("Service is null", service);
+        final Greeter port = service.getHttpsPort();
+        assertNotNull("Port is null", port);
+
+        updateAddressPort(port, PORT2);
+
+        assertEquals(port.greetMe("Kitty"), "Hello Kitty");
+
+        // Enable Async
+        ((BindingProvider)port).getRequestContext().put("use.async.http.conduit", true);
+
+        assertEquals(port.greetMe("Kitty"), "Hello Kitty");
+
+        ((java.io.Closeable)port).close();
+        bus.shutdown(true);
+    }
+}

--- a/systests/transports/src/test/resources/org/apache/cxf/systest/https/hostname/hostname-client-bethal.xml
+++ b/systests/transports/src/test/resources/org/apache/cxf/systest/https/hostname/hostname-client-bethal.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License. You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied. See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:http="http://cxf.apache.org/transports/http/configuration" xmlns:jaxws="http://cxf.apache.org/jaxws" xmlns:cxf="http://cxf.apache.org/core" xmlns:p="http://cxf.apache.org/policy" xmlns:sec="http://cxf.apache.org/configuration/security" xsi:schemaLocation="           http://www.springframework.org/schema/beans           http://www.springframework.org/schema/beans/spring-beans-4.2.xsd           http://cxf.apache.org/jaxws                           http://cxf.apache.org/schemas/jaxws.xsd           http://cxf.apache.org/transports/http/configuration   http://cxf.apache.org/schemas/configuration/http-conf.xsd           http://cxf.apache.org/configuration/security          http://cxf.apache.org/schemas/configuration/security.xsd           http://cxf.apache.org/core http://cxf.apache.org/schemas/core.xsd           http://cxf.apache.org/policy http://cxf.apache.org/schemas/policy.xsd">
+    
+    <cxf:bus>
+        <cxf:features>
+            <cxf:logging/>
+        </cxf:features>
+    </cxf:bus>
+    <http:conduit name="https://localhost:.*">
+        <http:tlsClientParameters>
+            <sec:trustManagers>
+                <sec:keyStore type="jks" password="password" resource="keys/Bethal.jks"/>
+            </sec:trustManagers>
+        </http:tlsClientParameters>
+    </http:conduit>
+</beans>

--- a/systests/transports/src/test/resources/org/apache/cxf/systest/https/hostname/hostname-server-bethal.xml
+++ b/systests/transports/src/test/resources/org/apache/cxf/systest/https/hostname/hostname-server-bethal.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License. You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied. See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jaxws="http://cxf.apache.org/jaxws" xmlns:http="http://cxf.apache.org/transports/http/configuration" xmlns:httpj="http://cxf.apache.org/transports/http-jetty/configuration" xmlns:sec="http://cxf.apache.org/configuration/security" xmlns:cxf="http://cxf.apache.org/core" xmlns:p="http://cxf.apache.org/policy" xsi:schemaLocation="         http://www.springframework.org/schema/beans                     http://www.springframework.org/schema/beans/spring-beans-4.2.xsd         http://cxf.apache.org/jaxws                                     http://cxf.apache.org/schemas/jaxws.xsd         http://cxf.apache.org/core http://cxf.apache.org/schemas/core.xsd         http://cxf.apache.org/policy http://cxf.apache.org/schemas/policy.xsd         http://cxf.apache.org/transports/http/configuration             http://cxf.apache.org/schemas/configuration/http-conf.xsd         http://cxf.apache.org/transports/http-jetty/configuration       http://cxf.apache.org/schemas/configuration/http-jetty.xsd         http://cxf.apache.org/configuration/security                    http://cxf.apache.org/schemas/configuration/security.xsd     ">
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
+    <cxf:bus>
+        <cxf:features>
+            <cxf:logging/>
+        </cxf:features>
+    </cxf:bus>
+   
+    <httpj:engine-factory id="non-localhost-match-settings">
+        <httpj:engine port="${testutil.ports.HostnameVerificationDeprecatedServer}">
+            <httpj:tlsServerParameters>
+                <sec:keyManagers keyPassword="password">
+                    <sec:keyStore type="jks" password="password" resource="keys/Bethal.jks"/>
+                </sec:keyManagers>
+                <sec:clientAuthentication want="false" required="false"/>
+            </httpj:tlsServerParameters>
+        </httpj:engine>
+    </httpj:engine-factory>
+    
+    <jaxws:endpoint xmlns:e="http://apache.org/hello_world/services" 
+                     xmlns:s="http://apache.org/hello_world/services" 
+                     id="NonLocalhostMatch"
+                     implementor="org.apache.cxf.systest.http.GreeterImpl" 
+                     address="https://localhost:${testutil.ports.HostnameVerificationDeprecatedServer}/SoapContext/HttpsPort" 
+                     serviceName="s:SOAPService" 
+                     endpointName="e:HttpsPort" depends-on="non-localhost-match-settings"/>
+                     
+    <httpj:engine-factory id="no-subject-alt-cn-match-settings">
+        <httpj:engine port="${testutil.ports.HostnameVerificationDeprecatedServer.2}">
+            <httpj:tlsServerParameters>
+                <sec:keyManagers keyPassword="security">
+                    <sec:keyStore type="jks" password="security" resource="keys/subjalt.jks"/>
+                </sec:keyManagers>
+                <sec:clientAuthentication want="false" required="false"/>
+                <sec:certAlias>nosubjaltcnmatch</sec:certAlias>
+            </httpj:tlsServerParameters>
+        </httpj:engine>
+    </httpj:engine-factory>
+    
+    <jaxws:endpoint xmlns:e="http://apache.org/hello_world/services" 
+                     xmlns:s="http://apache.org/hello_world/services" 
+                     id="NoSubjectAltCNMatch" 
+                     implementor="org.apache.cxf.systest.http.GreeterImpl" 
+                     address="https://localhost:${testutil.ports.HostnameVerificationDeprecatedServer.2}/SoapContext/HttpsPort" 
+                     serviceName="s:SOAPService" 
+                     endpointName="e:HttpsPort" depends-on="no-subject-alt-cn-match-settings"/>
+</beans>

--- a/systests/uncategorized/pom.xml
+++ b/systests/uncategorized/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/ws-rm/pom.xml
+++ b/systests/ws-rm/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/ws-security-examples/pom.xml
+++ b/systests/ws-security-examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/ws-security/pom.xml
+++ b/systests/ws-security/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/ws-specs/pom.xml
+++ b/systests/ws-specs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cxf-parent</artifactId>
         <groupId>org.apache.cxf</groupId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/systests/wsdl_maven/codegen/pom.xml
+++ b/systests/wsdl_maven/codegen/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <build>

--- a/systests/wsdl_maven/java2ws/pom.xml
+++ b/systests/wsdl_maven/java2ws/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <build>

--- a/systests/wsdl_maven/pom.xml
+++ b/systests/wsdl_maven/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.systests</groupId>
         <artifactId>cxf-systests</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>codegen</module>

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/common/pom.xml
+++ b/tools/common/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/corba/pom.xml
+++ b/tools/corba/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/javato/pom.xml
+++ b/tools/javato/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-tools</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>ws</module>

--- a/tools/javato/ws/pom.xml
+++ b/tools/javato/ws/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>common</module>

--- a/tools/validator/pom.xml
+++ b/tools/validator/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <properties>

--- a/tools/wadlto/jaxrs/pom.xml
+++ b/tools/wadlto/jaxrs/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/wadlto/pom.xml
+++ b/tools/wadlto/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-tools</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>jaxrs</module>

--- a/tools/wsdlto/core/pom.xml
+++ b/tools/wsdlto/core/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/wsdlto/databinding/jaxb/pom.xml
+++ b/tools/wsdlto/databinding/jaxb/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/wsdlto/frontend/javascript/pom.xml
+++ b/tools/wsdlto/frontend/javascript/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/wsdlto/frontend/jaxws/pom.xml
+++ b/tools/wsdlto/frontend/jaxws/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/wsdlto/misc/pom.xml
+++ b/tools/wsdlto/misc/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/wsdlto/pom.xml
+++ b/tools/wsdlto/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-tools</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
     </parent>
     <modules>
         <module>core</module>

--- a/tools/wsdlto/test/pom.xml
+++ b/tools/wsdlto/test/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.6-TT-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <dependencies>


### PR DESCRIPTION
backport fixes for:
CVE-2017-12624 (http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12624): CXF-7507
CVE-2016-8739 (http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-8739): Letting CXF StaxUtils prepare XMLStreamReader for Atom reads
CVE-2017-5656 (http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5656): backport fix for CVE-2017-5656
CVE-2017-3156 (http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3156): Doing a better bytes comparison in some of JAXRS OAuth2/Jose code
CVE-2018-8039 (http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8039): Fix hostname verification using the deprecated SSL stack
CVE-2016-6812 (http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6812): CXF-6216